### PR TITLE
Fix gallery() and label_gallery() to handle None values and display images properly

### DIFF
--- a/src/unibox/nb_helpers/ipython_utils.py
+++ b/src/unibox/nb_helpers/ipython_utils.py
@@ -135,7 +135,7 @@ def _label_gallery(
 
     # convert to rgb if necessary
     for i, img in enumerate(images):
-        if img.mode in ("RGBA", "P"):
+        if img is not None and img.mode in ("RGBA", "P"):
             images[i] = img.convert("RGB")
 
     # Process images: resize and handle None

--- a/src/unibox/nb_helpers/ipython_utils.py
+++ b/src/unibox/nb_helpers/ipython_utils.py
@@ -64,7 +64,7 @@ def _gallery(
                 image.thumbnail((thumbnail_size, thumbnail_size))
 
             # Ensure image is in RGB mode for saving as JPEG
-            if image.mode in ("RGBA", "P"):
+            if image is not None and image.mode in ("RGBA", "P"):
                 image = image.convert("RGB")
 
             buffered = BytesIO()
@@ -87,13 +87,12 @@ def _gallery(
             </figure>
         """)
 
-    return HTML(
+    display(HTML(
         data=f"""
         <div style="display: flex; flex-flow: row wrap; text-align: center;">
         {''.join(figures)}
         </div>
-    """,
-    )
+    """))
 
 
 import base64


### PR DESCRIPTION
This PR fixes issues in both gallery() and label_gallery() functions:
1. Adds checks for None values before accessing image.mode
2. Ensures gallery() displays images by calling display()